### PR TITLE
 Add Gnu_Linux Script for easy installation with shortcut

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Tools/GNU_LINUX_Installation-Script"]
-	path = Tools/GNU_LINUX_Installation-Script
-	url = https://github.com/Unitystation-fork/Unitystation-Others/tree/main/Installation-Script

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Tools/GnuLinux_Install_Script"]
-	path = Tools/GnuLinux_Install_Script
-	url = https://github.com/Unitystation-fork/Unitystation-Others.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Tools/GnuLinux_Install_Script"]
+	path = Tools/GnuLinux_Install_Script
+	url = https://github.com/Unitystation-fork/Unitystation-Others.git


### PR DESCRIPTION
### Purpose
This script was written by a former member of my team. 
She made it viable on any Gnu_linux system.

The goal is to have a "one line" installation, very popular on Ubuntu systems, because it can be executed by people without much knowledge, thus limiting possible errors.

The script will download the latest version of the hub, unzip it, create a desktop shortcut, and delete the useless zip archive.

### Notes
You may need to copy the .desktop to `~/.locale/usr/share/application/`
but this is a rare case. If others report this, I will modify the script accordingly.

it is up to date for version 931 and works. 
@Peulleieoyukino
@Fr-Dae

### Changelog:
CL: [New] Add Gnu_Linux Script for easy installation with shortcut